### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,18 +9,22 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:wemos_d1_mini32]
-platform = espressif32
+platform = platformio/espressif32@3.5.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
+; change to COM on windows devices
 upload_port = /dev/ttyUSB0
+; change to COM on windows devices
 monitor_port = /dev/ttyUSB0
 lib_deps = 
 	SPI
-	can_common=https://github.com/collin80/can_common.git#07605a2a9f4963ee68a9ecf7790d38b22f6d2cdf
-	esp32_can=https://github.com/collin80/esp32_can.git#7c3174f14aed8c025d337cee89f3e4de4e31e36b
+	can_common=https://github.com/collin80/can_common.git
+	esp32_can=https://github.com/collin80/esp32_can.git
+	https://github.com/knolleary/pubsubclient.git
+	
 [env:remoteesp32]
-platform = espressif32
+platform = platformio/espressif32@3.5.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
@@ -28,5 +32,6 @@ upload_protocol = espota
 upload_port = 192.168.107.135
 lib_deps = 
 	SPI
-	can_common=https://github.com/collin80/can_common.git#07605a2a9f4963ee68a9ecf7790d38b22f6d2cdf
-	esp32_can=https://github.com/collin80/esp32_can.git#7c3174f14aed8c025d337cee89f3e4de4e31e36b
+	can_common=https://github.com/collin80/can_common.git
+	esp32_can=https://github.com/collin80/esp32_can.git
+	https://github.com/knolleary/pubsubclient.git


### PR DESCRIPTION
1)Updated espressif32 platform version.

As from platform package version 4.0.0 the ESP32 crashes with this software and throws out some weird FreeRTOS related errors.
This is due to the updated framework-arduinoespressif32 as of version 4.0.0
I tested different platform package versions and 3.5.0 was the last stable one.

2)Added extra info on line 16 and 18

3)Added working proposals from issue #13  
Line22-24
Line 35-37