### PR TITLE
Added optional gpio param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode/ipch
 .vscode/
 src/secrets.h
+.idea/

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -121,8 +121,8 @@ GEN_TEXTSENSORS_SCHEMA = {
 CONFIG_SCHEMA = cv.All(
     cv.Schema({
         cv.GenerateID(): cv.declare_id(Comfoair),
-        cv.Optional(CONF_RX_PIN, default=GPIO_NUM_21): pins.internal_gpio_input_pin_number,
-        cv.Optional(CONF_TX_PIN, default=GPIO_NUM_25): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_RX_PIN, default=21): pins.internal_gpio_input_pin_number,
+        cv.Optional(CONF_TX_PIN, default=25): pins.internal_gpio_output_pin_number,
     })
     .extend(GEN_SENSORS_SCHEMA)
     .extend(GEN_TEXTSENSORS_SCHEMA)

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -121,8 +121,8 @@ GEN_TEXTSENSORS_SCHEMA = {
 CONFIG_SCHEMA = cv.All(
     cv.Schema({
         cv.GenerateID(): cv.declare_id(Comfoair),
-        cv.Required(CONF_RX_PIN): pins.internal_gpio_input_pin_number,
-        cv.Required(CONF_TX_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_RX_PIN, default=GPIO_NUM_21): pins.internal_gpio_input_pin_number,
+        cv.Optional(CONF_TX_PIN, default=GPIO_NUM_25): pins.internal_gpio_output_pin_number,
     })
     .extend(GEN_SENSORS_SCHEMA)
     .extend(GEN_TEXTSENSORS_SCHEMA)

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -2,7 +2,8 @@ import math
 import esphome.codegen as cg
 import esphome.cpp_generator as cppg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_VERSION, CONF_NAME, UNIT_PERCENT
+from esphome import pins
+from esphome.const import CONF_ID, CONF_VERSION, CONF_NAME, UNIT_PERCENT, CONF_RX_PIN, CONF_TX_PIN
 from esphome.components import text_sensor, binary_sensor, sensor
 from enum import Enum
 
@@ -120,6 +121,8 @@ GEN_TEXTSENSORS_SCHEMA = {
 CONFIG_SCHEMA = cv.All(
     cv.Schema({
         cv.GenerateID(): cv.declare_id(Comfoair),
+        cv.Required(CONF_RX_PIN): pins.internal_gpio_input_pin_number,
+        cv.Required(CONF_TX_PIN): pins.internal_gpio_output_pin_number,
     })
     .extend(GEN_SENSORS_SCHEMA)
     .extend(GEN_TEXTSENSORS_SCHEMA)
@@ -136,6 +139,8 @@ async def to_code(config):
 
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+    cg.add(var.set_rx(config[CONF_RX_PIN]))
+    cg.add(var.set_tx(config[CONF_TX_PIN]))
     for key, value in sensors.items():
         sens = await sensor.new_sensor(config[key])
 

--- a/components/comfoair/comfoair.cpp
+++ b/components/comfoair/comfoair.cpp
@@ -10,7 +10,7 @@ namespace comfoair {
 static const char *TAG = "comfoair.component";
 
 void Comfoair::setup(){
-    CAN0.setCANPins( (gpio_num_t) this->rx_, (gpio_num_t) this->tx);
+    CAN0.setCANPins( (gpio_num_t) this->rx_, (gpio_num_t) this->tx_);
     CAN0.begin(50000);
     CAN0.watchFor();
     register_service(&Comfoair::send_command, "send_command", {"command"});

--- a/components/comfoair/comfoair.cpp
+++ b/components/comfoair/comfoair.cpp
@@ -10,7 +10,7 @@ namespace comfoair {
 static const char *TAG = "comfoair.component";
 
 void Comfoair::setup(){
-    CAN0.setCANPins(GPIO_NUM_21, GPIO_NUM_25);
+    CAN0.setCANPins( (gpio_num_t) this->rx_, (gpio_num_t) this->tx);
     CAN0.begin(50000);
     CAN0.watchFor();
     register_service(&Comfoair::send_command, "send_command", {"command"});

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -20,6 +20,8 @@ class ComfoSensor {
 
 class Comfoair: public Component, public esphome::api::CustomAPIDevice {
  public:
+  void set_rx(int rx) { rx_ = rx; }
+  void set_tx(int tx) { tx_ = tx; }
   void register_sensor(sensor::Sensor *obj, int PDOID, int conversionType, int divider) {
     ComfoSensor<sensor::Sensor, int> *cs = new ComfoSensor<sensor::Sensor, int>();
     cs->sensor = obj;
@@ -45,6 +47,8 @@ class Comfoair: public Component, public esphome::api::CustomAPIDevice {
   CAN_FRAME canMessage;
 
  protected:
+  int rx_{-1};
+  int tx_{-1};
   uint8_t sequence = 0;
   std::map<int, ComfoSensor<sensor::Sensor, int>> sensors;
   std::map<int, ComfoSensor<text_sensor::TextSensor,  std::string (*)(uint8_t *)>> textSensors;


### PR DESCRIPTION
I am using a different board from olimex that has CAN and Ethernet interface :  (+ they sell a metal case)
https://www.olimex.com/Products/IoT/ESP32/ESP32-EVB/open-source-hardware.

For this board, pin are different so I have added as an option to be able to specify another gpio.
Here is the config I am using for Olimex board : 

```
comfoair:
    rx_pin: GPIO35
    tx_pin: GPIO5
```
